### PR TITLE
Add xarray entrypoint for ftml reading

### DIFF
--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -3,10 +3,12 @@ from dataclasses import dataclass
 from typing import Optional
 import numpy as np
 import xarray as xr
+from xarray.backends import BackendEntrypoint
 from scipy.optimize import minimize
 import pyproj
 from warnings import warn
 import xml.etree.ElementTree as ET
+import pathlib
 
 
 geod = pyproj.Geod(ellps="WGS84")
@@ -411,3 +413,21 @@ def open_ftml(path):
     )
 
     return ds
+
+
+class FlightTrackEntrypoint(BackendEntrypoint):
+    def open_dataset(self, filename_or_obj, *, drop_variables=None):
+        return open_ftml(filename_or_obj)
+
+    open_dataset_parameters = ["filename_or_obj"]
+
+    def guess_can_open(self, filename_or_obj):
+        try:
+            ext = pathlib.Path(filename_or_obj).suffix
+        except TypeError:
+            return False
+        return ext in {".ftml"}
+
+    description = "Use .ftml files in Xarray"
+
+    url = "https://github.com/orcestra-campaign/pyorcestra"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ initial-content = """
   __version_tuple__ = (0, 0, 0)
 """
 
+[tool.poetry.plugins."xarray.backends"]
+ftml = "orcestra.flightplan:FlightTrackEntrypoint"
+
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
This PR adds an `ftml` entrypoint to the list of xarray backends, which allows users to simply open FTML files using `xr.open_dataset()`.