### PR TITLE
Read CSV index of sattracks to select correct forecast.

### DIFF
--- a/orcestra/sat.py
+++ b/orcestra/sat.py
@@ -116,6 +116,8 @@ class CalipsoTrackLoader:
 
 
 class SattrackLoader:
+    server = "https://sattracks.orcestra-campaign.org/"
+
     def __init__(self, satelite_name, forecast_day):
         """
         Loader for satallite tracks from sattracks.orcestra-campaign.org.
@@ -136,6 +138,16 @@ class SattrackLoader:
         self.forecast_day = pd.Timestamp(np.datetime64(forecast_day))
 
     @lru_cache
+    def _get_index(self):
+        return (
+            pd.read_csv(
+                self.server + "index.csv", parse_dates=["forecast_day", "valid_day"]
+            )
+            .set_index(["sat", "valid_day", "forecast_day"])
+            .sort_index()
+        )
+
+    @lru_cache
     def get_track_for_day(self, day):
         """
         Get track data for a given day
@@ -151,7 +163,9 @@ class SattrackLoader:
             Dataset containing forcasted satellite track.
         """
         valid_day = pd.Timestamp(np.datetime64(day))
-        url = f"https://sattracks.orcestra-campaign.org/{valid_day:%Y%m%d}/PERCUSION_ORBIT_FCST_{self.satelite_name}_ORBLTP_CAPE_VERDE_ROI_{self.forecast_day:%Y%m%d}_{valid_day:%Y%m%d}.txt"
+        index_for_day = self._get_index().loc[(self.satelite_name, valid_day)]
+
+        url = self.server + index_for_day.loc[self.forecast_day]["forecast_file"]
         res = requests.get(url)
         res.raise_for_status()
         text = res.text

--- a/orcestra/sat.py
+++ b/orcestra/sat.py
@@ -1,3 +1,4 @@
+import warnings
 import fsspec
 import requests
 import re
@@ -164,6 +165,14 @@ class SattrackLoader:
         """
         valid_day = pd.Timestamp(np.datetime64(day))
         index_for_day = self._get_index().loc[(self.satelite_name, valid_day)]
+
+        if (
+            self.forecast_day in index_for_day.index
+            and self.forecast_day < index_for_day.index.max()
+        ):
+            warnings.warn(
+                f"You are using an old forecast (issued on {self.forecast_day.date()}) for {self.satelite_name} on {valid_day.date()}! The newest forecast issued so far was issued on {index_for_day.index.max().date()}."
+            )
 
         url = self.server + index_for_day.loc[self.forecast_day]["forecast_file"]
         res = requests.get(url)


### PR DESCRIPTION
The file naming convention in sattracks has changed. In oder to be more robust to similar changes in future, this PR uses the newly generated CSV index from the sattracks repo to select the right forecast files.

With the CSV index, we can now also issue a warning if an old forecast is used.

Fixes #11