### PR TITLE
Add Flightlevel to flight plan

### DIFF
--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -32,6 +32,7 @@ class LatLon:
     lat: float
     lon: float
     label: Optional[str] = None
+    fl: Optional[float] = None
 
     def towards(self, other, fraction=None, distance=None) -> LatLon:
         if fraction is None and distance is None:

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import dataclasses
 from dataclasses import dataclass
 from typing import Optional
 import numpy as np
@@ -48,7 +49,9 @@ class LatLon:
         return LatLon(lat, lon)
 
     def assign_label(self, label: str) -> LatLon:
-        return LatLon(self.lat, self.lon, label)
+        return self.assign(label=label)
+
+    assign = dataclasses.replace
 
 
 bco = LatLon(13.079773, -59.487634, "BCO")

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -55,8 +55,8 @@ class LatLon:
     assign = dataclasses.replace
 
 
-bco = LatLon(13.079773, -59.487634, "BCO")
-sal = LatLon(16.73448797020352, -22.94397423993749, "SAL")
+bco = LatLon(13.079773, -59.487634, "BCO", fl=0)
+sal = LatLon(16.73448797020352, -22.94397423993749, "SAL", fl=0)
 
 
 def expand_path(path: list[LatLon], dx=None, max_points=None):
@@ -67,11 +67,13 @@ def expand_path(path: list[LatLon], dx=None, max_points=None):
     path = simplify_path(path)
     lon_points = np.asarray([p.lon for p in path])
     lat_points = np.asarray([p.lat for p in path])
+    fl_points = np.asarray([p.fl if p.fl is not None else np.nan for p in path])
     labels = [p.label for p in path]
 
     if len(path) < 2:
         lons = lon_points
         lats = lat_points
+        fls = fl_points
         dists = np.zeros_like(lon_points)
         indices = np.arange(len(lon_points))
     else:
@@ -97,16 +99,19 @@ def expand_path(path: list[LatLon], dx=None, max_points=None):
 
         lons = []
         lats = []
+        fls = []
         dists = []
         indices = []
 
         distance_so_far = 0
         indices_so_far = 0
-        for lon1, lat1, lon2, lat2, n, d in zip(
+        for lon1, lat1, fl1, lon2, lat2, fl2, n, d in zip(
             lon_points[:-1],
             lat_points[:-1],
+            fl_points[:-1],
             lon_points[1:],
             lat_points[1:],
+            fl_points[1:],
             points_per_segment,
             dist,
         ):
@@ -115,6 +120,7 @@ def expand_path(path: list[LatLon], dx=None, max_points=None):
             lons.append(lon)
             lats.append([lat1])
             lats.append(lat)
+            fls.append(np.linspace(fl1, fl2, n + 2)[:-1])
             dists.append(distance_so_far + np.linspace(0.0, d, n + 2)[:-1])
             indices.append(indices_so_far)
             distance_so_far += d
@@ -122,11 +128,13 @@ def expand_path(path: list[LatLon], dx=None, max_points=None):
 
         lons.append([lon_points[-1]])
         lats.append([lat_points[-1]])
+        fls.append([fl_points[-1]])
         dists.append([distance_so_far])
         indices.append(indices_so_far)
 
         lons = np.concatenate(lons)
         lats = np.concatenate(lats)
+        fls = np.concatenate(fls)
         dists = np.concatenate(dists)
 
         il = list(
@@ -149,6 +157,7 @@ def expand_path(path: list[LatLon], dx=None, max_points=None):
             "distance": ("distance", dists),
             "lon": ("distance", lons),
             "lat": ("distance", lats),
+            "fl": ("distance", fls),
         },
     )
 
@@ -212,7 +221,7 @@ class IntoCircle:
             angles,
             np.full_like(angles, self.radius),
         )
-        points = list(map(LatLon, lats, lons))
+        points = [LatLon(lat, lon, fl=self.center.fl) for lat, lon in zip(lats, lons)]
         if self.center.label is not None:
             points[0] = points[0].assign_label(f"{self.center.label}_in")
             points[-1] = points[-1].assign_label(f"{self.center.label}_out")
@@ -320,6 +329,25 @@ def plot_cwv(var, ax=None, levels=None):
         ax=ax,
     )
     plt.clabel(contour_lines, inline=True, fontsize=8, colors="grey", fmt="%d")
+
+
+def vertical_preview(path):
+    import matplotlib.pylab as plt
+
+    path = path_as_ds(path)
+
+    fig, ax = plt.subplots(figsize=(15, 6))
+
+    secax = ax.secondary_xaxis("top")
+    secax.set_xlabel("waypoints")
+    secax.set_xticks(
+        path.distance[path.waypoint_indices],
+        path.waypoint_labels.values,
+        rotation="vertical",
+    )
+    for point in path.distance[path.waypoint_indices]:
+        ax.axvline(point, color="k", lw=1)
+    ax.plot(path.distance, path.fl, color="C1", lw=2)
 
 
 def path_preview(path, coastlines=True, gridlines=True, ax=None, size=8, aspect=16 / 9):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ cartopy = "*"
 pyproj = "*"
 textalloc = "*"
 
+[tool.poetry.group.test.dependencies]
+pytest = "*"
+pytest-watch = "*"
+
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
@@ -51,7 +55,7 @@ initial-content = """
 
   __version__ = '0.0.0'
   __version_tuple__ = (0, 0, 0)
-"""
+  """
 
 [tool.poetry.plugins."xarray.backends"]
 ftml = "orcestra.flightplan:FlightTrackEntrypoint"

--- a/tests/test_flightplan.py
+++ b/tests/test_flightplan.py
@@ -26,9 +26,18 @@ def test_point_at_distance(geod):
     npt.assert_allclose(spath[1].lon, geod.fwd(1, 0, -90, 50e3)[0])
 
 
-def test_assign_label():
+def test_assign_label_old():
     a = fp.LatLon(3, 7)
     b = a.assign_label("test")
+    assert b.label == "test"
+    assert a.label is None
+    assert a.lat == b.lat == 3
+    assert a.lon == b.lon == 7
+
+
+def test_assign_label():
+    a = fp.LatLon(3, 7)
+    b = a.assign(label="test")
     assert b.label == "test"
     assert a.label is None
     assert a.lat == b.lat == 3

--- a/tests/test_flightplan.py
+++ b/tests/test_flightplan.py
@@ -1,0 +1,35 @@
+import pytest
+import pyproj
+import numpy.testing as npt
+import orcestra.flightplan as fp
+
+
+@pytest.fixture
+def geod():
+    return pyproj.Geod(ellps="WGS84")
+
+
+def test_point_at_distance(geod):
+    a = fp.LatLon(0, 0)
+    b = fp.LatLon(0, 1)
+    path = [a, a.towards(b, distance=50e3), b]
+    spath = fp.simplify_path(path)
+    print(spath)
+
+    assert spath[1].lat == 0
+    assert spath[1].lon == geod.fwd(0, 0, 90, 50e3)[0]
+
+    path = [a, b.towards(a, distance=50e3), b]
+    spath = fp.simplify_path(path)
+
+    npt.assert_allclose(spath[1].lat, 0)
+    npt.assert_allclose(spath[1].lon, geod.fwd(1, 0, -90, 50e3)[0])
+
+
+def test_assign_label():
+    a = fp.LatLon(3, 7)
+    b = a.assign_label("test")
+    assert b.label == "test"
+    assert a.label is None
+    assert a.lat == b.lat == 3
+    assert a.lon == b.lon == 7

--- a/tests/test_flightplan.py
+++ b/tests/test_flightplan.py
@@ -27,18 +27,30 @@ def test_point_at_distance(geod):
 
 
 def test_assign_label_old():
-    a = fp.LatLon(3, 7)
+    a = fp.LatLon(3, 7, fl=300)
     b = a.assign_label("test")
     assert b.label == "test"
     assert a.label is None
     assert a.lat == b.lat == 3
     assert a.lon == b.lon == 7
+    assert a.fl == b.fl == 300
 
 
 def test_assign_label():
-    a = fp.LatLon(3, 7)
+    a = fp.LatLon(3, 7, fl=300)
     b = a.assign(label="test")
     assert b.label == "test"
     assert a.label is None
     assert a.lat == b.lat == 3
     assert a.lon == b.lon == 7
+    assert a.fl == b.fl == 300
+
+
+def test_assign_flightlevel():
+    a = fp.LatLon(3, 7, label="test")
+    b = a.assign(fl=350)
+    assert b.fl == 350
+    assert a.fl is None
+    assert a.lat == b.lat == 3
+    assert a.lon == b.lon == 7
+    assert a.label == b.label == "test"


### PR DESCRIPTION
This PR adds a `fl` (flightlevel) attribute to `LatLon` and adds the `vertical_preview` function to have a quick look at the vertical component of the flight plan.

It also generalizes the `assign_label` method of `LatLon` to just `assign`, which is capable to change any of the attributes, e.g.:
```
p = p.assign(label="text", fl=360)
```

`assign_label("text")` still works, but `assign(label="text")` should be preferred.

This PR thereby allows to specify flight levels for each point (for circles, the level of the center point is used) in the flight plan. In future PR(s) this information will also be used to calculate flight time.