### PR TITLE
Add kwargs to preview

### DIFF
--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -309,7 +309,7 @@ def track_len(ds):
     return path_len(ds)
 
 
-def plot_path(path, ax, color=None, label=None, show_waypoints=False):
+def plot_path(path, ax, color="C1", label=None, show_waypoints=True):
     import cartopy.crs as ccrs
 
     path = path_as_ds(path)
@@ -394,7 +394,9 @@ def vertical_preview(path):
     ax.plot(path.distance, path.fl, color="C1", lw=2)
 
 
-def path_preview(path, coastlines=True, gridlines=True, ax=None, size=8, aspect=16 / 9):
+def path_preview(
+    path, coastlines=True, gridlines=True, ax=None, size=8, aspect=16 / 9, **kwargs
+):
     import matplotlib.pylab as plt
     import cartopy.crs as ccrs
 
@@ -437,7 +439,7 @@ def path_preview(path, coastlines=True, gridlines=True, ax=None, size=8, aspect=
         no_cartopy_download_warning()
         ax.gridlines(draw_labels=True, alpha=0.25)
 
-    plot_path(path, ax=ax, label="path", color="C1")
+    plot_path(path, ax=ax, label="path", **kwargs)
     return ax
 
 

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -309,7 +309,7 @@ def track_len(ds):
     return path_len(ds)
 
 
-def plot_path(path, ax, color=None, label=None, show_waypoints=True):
+def plot_path(path, ax, color=None, label=None, show_waypoints=False):
     import cartopy.crs as ccrs
 
     path = path_as_ds(path)

--- a/orcestra/weathermaps.py
+++ b/orcestra/weathermaps.py
@@ -68,6 +68,8 @@ def _create_GOES_variable(
     }
     return GOES_PRODUCT_DICT[variable]
 
-def goes_image(image_date ,satellite='16', product='ABI', domain='F', variable='TrueColor'):
+def goes_image(image_date ,ax , satellite='16', product='ABI', domain='F', variable='TrueColor'):
     snapshot = goes_nearesttime(image_date, satellite=satellite, product=product, domain = domain)
-    return _create_GOES_variable(snapshot, variable)
+    ax.imshow(_create_GOES_variable(snapshot, variable), transform=snapshot.rgb.crs, regrid_shape=3500,
+              interpolation='nearest')     
+    return 

--- a/orcestra/weathermaps.py
+++ b/orcestra/weathermaps.py
@@ -68,7 +68,7 @@ def _create_GOES_variable(
     }
     return GOES_PRODUCT_DICT[variable]
 
-def goes_image(image_date ,ax , satellite='16', product='ABI', domain='F', variable='TrueColor'):
+def goes_overlay(image_date ,ax , satellite='16', product='ABI', domain='F', variable='TrueColor'):
     snapshot = goes_nearesttime(image_date, satellite=satellite, product=product, domain = domain)
     ax.imshow(_create_GOES_variable(snapshot, variable), transform=snapshot.rgb.crs, regrid_shape=3500,
               interpolation='nearest')     

--- a/orcestra/weathermaps.py
+++ b/orcestra/weathermaps.py
@@ -1,6 +1,7 @@
+from goes2go.data import goes_nearesttime, goes_latest
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
-
+import xarray as xr
 
 def plot_sat(
     date_time_obj,
@@ -34,3 +35,39 @@ def plot_sat(
         extent=[lon_min, lon_max, lat_min, lat_max],
         transform=ccrs.PlateCarree(),
     )
+
+# used to create a goes image that can be plotted with imshow
+
+def _create_GOES_variable(
+        goes_object: xr.Dataset, variable: str, gamma:float = 1.2
+        ):
+    GOES_PRODUCT_DICT = {
+        "AirMass": goes_object.rgb.AirMass,
+        "AirMassTropical": goes_object.rgb.AirMassTropical,
+        "AirMassTropicalPac": goes_object.rgb.AirMassTropicalPac,
+        "Ash": goes_object.rgb.Ash,
+        "DayCloudConvection": goes_object.rgb.DayCloudConvection,
+        "DayCloudPhase": goes_object.rgb.DayCloudPhase,
+        "DayConvection": goes_object.rgb.DayConvection,
+        "DayLandCloud": goes_object.rgb.DayLandCloud,
+        "DayLandCloudFire": goes_object.rgb.DayLandCloudFire,
+        "DaySnowFog": goes_object.rgb.DaySnowFog,
+        "DifferentialWaterVapor": goes_object.rgb.DifferentialWaterVapor,
+        "Dust": goes_object.rgb.Dust,
+        "FireTemperature": goes_object.rgb.FireTemperature,
+        "NaturalColor": goes_object.rgb.NaturalColor(gamma=gamma),
+        "NightFogDifference": goes_object.rgb.NightFogDifference,
+        "NighttimeMicrophysics": goes_object.rgb.NighttimeMicrophysics,
+        "NormalizedBurnRatio": goes_object.rgb.NormalizedBurnRatio,
+        "RocketPlume": goes_object.rgb.RocketPlume,
+        "SeaSpray": goes_object.rgb.SeaSpray(gamma=gamma),
+        "SplitWindowDifference": goes_object.rgb.SplitWindowDifference,
+        "SulfurDioxide": goes_object.rgb.SulfurDioxide,
+        "TrueColor": goes_object.rgb.TrueColor(gamma=gamma),
+        "WaterVapor": goes_object.rgb.WaterVapor,
+    }
+    return GOES_PRODUCT_DICT[variable]
+
+def goes_image(image_date ,satellite='16', product='ABI', domain='F', variable='TrueColor'):
+    snapshot = goes_nearesttime(image_date, satellite=satellite, product=product, domain = domain)
+    return _create_GOES_variable(snapshot, variable)

--- a/orcestra/weathermaps.py
+++ b/orcestra/weathermaps.py
@@ -1,4 +1,3 @@
-from goes2go.data import goes_nearesttime
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import xarray as xr
@@ -38,10 +37,8 @@ def plot_sat(
     )
 
 
-# used to create a goes image that can be plotted with imshow
-
-
 def _create_GOES_variable(goes_object: xr.Dataset, variable: str, gamma: float = 1.2):
+    """Create a GOES image that can be plotted with `plt.imshow()`."""
     GOES_PRODUCT_DICT = {
         "AirMass": goes_object.rgb.AirMass,
         "AirMassTropical": goes_object.rgb.AirMassTropical,
@@ -73,6 +70,8 @@ def _create_GOES_variable(goes_object: xr.Dataset, variable: str, gamma: float =
 def goes_overlay(
     image_date, ax, satellite="16", product="ABI", domain="F", variable="TrueColor"
 ):
+    from goes2go.data import goes_nearesttime
+
     snapshot = goes_nearesttime(
         image_date, satellite=satellite, product=product, domain=domain
     )

--- a/orcestra/weathermaps.py
+++ b/orcestra/weathermaps.py
@@ -1,7 +1,8 @@
-from goes2go.data import goes_nearesttime, goes_latest
+from goes2go.data import goes_nearesttime
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import xarray as xr
+
 
 def plot_sat(
     date_time_obj,
@@ -36,11 +37,11 @@ def plot_sat(
         transform=ccrs.PlateCarree(),
     )
 
+
 # used to create a goes image that can be plotted with imshow
 
-def _create_GOES_variable(
-        goes_object: xr.Dataset, variable: str, gamma:float = 1.2
-        ):
+
+def _create_GOES_variable(goes_object: xr.Dataset, variable: str, gamma: float = 1.2):
     GOES_PRODUCT_DICT = {
         "AirMass": goes_object.rgb.AirMass,
         "AirMassTropical": goes_object.rgb.AirMassTropical,
@@ -68,8 +69,17 @@ def _create_GOES_variable(
     }
     return GOES_PRODUCT_DICT[variable]
 
-def goes_overlay(image_date ,ax , satellite='16', product='ABI', domain='F', variable='TrueColor'):
-    snapshot = goes_nearesttime(image_date, satellite=satellite, product=product, domain = domain)
-    ax.imshow(_create_GOES_variable(snapshot, variable), transform=snapshot.rgb.crs, regrid_shape=3500,
-              interpolation='nearest')     
-    return 
+
+def goes_overlay(
+    image_date, ax, satellite="16", product="ABI", domain="F", variable="TrueColor"
+):
+    snapshot = goes_nearesttime(
+        image_date, satellite=satellite, product=product, domain=domain
+    )
+    ax.imshow(
+        _create_GOES_variable(snapshot, variable),
+        transform=snapshot.rgb.crs,
+        regrid_shape=3500,
+        interpolation="nearest",
+    )
+    return


### PR DESCRIPTION
This is supposed to be a minimally invasive change that allows calls to path_preview without waypoint_indices.  There is one possible side effect as by using kwargs, to keep the color default at `C1` for path_preview, it was redefined from `none` to `C1` in the argument list of `plot_path`.