### PR TITLE
Add flox to list of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 python = ">=3.10"
 numpy = "*"
 xarray = "*"
+flox = "*"  # part of xarray[accel]
 astropy = "*"
 sgp4 = "*"
 scipy = "*"


### PR DESCRIPTION
flox is part of xarray's "accel" dependency. Adding `xarray[accel]` directly will cause the poetry installation to fail. As a workaround, directly depend on "accel" to speed up groupby calculations.