### PR TITLE
parse_datestr: accept np.datetime64

### DIFF
--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -66,7 +66,7 @@ class LatLon:
     time: Optional[datetime.datetime | str] = None
 
     def __post_init__(self):
-        if isinstance(self.time, str):
+        if isinstance(self.time, (str, np.datetime64, xr.DataArray)):
             super().__setattr__("time", parse_datestr(self.time))
         if self.time is not None and (
             self.time.tzinfo is None or self.time.tzinfo.utcoffset(self.time) is None

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,6 +1,8 @@
 from datetime import datetime, date
 from zoneinfo import ZoneInfo
 
+import numpy as np
+
 from orcestra.utils import parse_datestr
 
 
@@ -21,3 +23,9 @@ def test_parse_date_iana():
         tzinfo=ZoneInfo("Europe/Berlin")
     )
     assert parse_datestr("2024-01-01 00:00[Europe/Berlin]") == refdate
+
+
+def test_parse_numpy():
+    refdate = datetime.fromisoformat("2024-01-01 00:00").replace(tzinfo=ZoneInfo("UTC"))
+
+    assert parse_datestr(np.datetime64("2024-01-01 00:00")) == refdate


### PR DESCRIPTION
Numpy datetime64 are commonly returned e.g. by parsing CF compliant datasets. In all cases I know, np.datetime64 actually refers to UTC time, so I'd guess parsing it as UTC would be a good option here too.