### PR TITLE
fix time assignment in flightplan

### DIFF
--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -211,6 +211,7 @@ def expand_path(path: list[LatLon], dx=None, max_points=None):
         fls = np.concatenate(fls)
         dists = np.concatenate(dists)
 
+        simple_path_indices = np.array(indices)
         il = list(
             zip(*[(i, label) for i, label in zip(indices, labels) if label is not None])
         )
@@ -256,7 +257,7 @@ def expand_path(path: list[LatLon], dx=None, max_points=None):
             )
 
         if "duration" in ds:
-            offset = ds.duration.values[ds.waypoint_indices[i]]
+            offset = ds.duration.values[simple_path_indices[i]]
             ds = ds.assign(time=ds.duration - offset + reftime)
 
     return ds

--- a/tests/test_flightplan.py
+++ b/tests/test_flightplan.py
@@ -1,5 +1,6 @@
 import pytest
 import pyproj
+import numpy as np
 import numpy.testing as npt
 import orcestra.flightplan as fp
 
@@ -54,3 +55,12 @@ def test_assign_flightlevel():
     assert a.lat == b.lat == 3
     assert a.lon == b.lon == 7
     assert a.label == b.label == "test"
+
+
+def test_fix_waypoint_time():
+    a = fp.LatLon(0, 0, fl=300)
+    b = fp.LatLon(0, 1, fl=300, time="2014-01-01T00:00:00")
+    path = fp.expand_path([a, b], max_points=2)
+    print(path)
+    assert path.time.values[-1] == np.datetime64("2014-01-01T00:00:00")
+    assert path.time.values[0] < path.time.values[-1]


### PR DESCRIPTION
This commit correctly uses the indices of all LatLon points to select at which point along the flight path the time should be fixed. Previously, only labelled points have been accounted, which doesn't work if either points are unlabelled, or circles are inserted before the time fix.