### PR TITLE
Remove hard dependency on healpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ astropy = "*"
 cartopy = "*"
 easygems = ">=0.0.8"
 flox = "*"  # part of xarray[accel]
-healpy = "*"
 intake = "<2.0.0"
 intake-xarray = "*"
 ipywidgets = "*"


### PR DESCRIPTION
Healpy is only used as a lazy-import in one of the flight plan quicklook functions. This PR removes it from the list of hard dependencies to possibly allow an installation for Windows users (see #57)