### PR TITLE
Export TXT Version

### DIFF
--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -167,6 +167,14 @@ class FlightPlan:
             .replace(tzinfo=datetime.timezone.utc)
         )
 
+    @cached_property
+    def takeoff_time(self):
+        return self.computed_time_at_raw_index(0)
+
+    @cached_property
+    def landing_time(self):
+        return self.computed_time_at_raw_index(-1, end=True)
+
 
 def attach_flight_performance(ds, performance):
     second = np.timedelta64(1000000000, "ns")

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -487,10 +487,7 @@ def plot_path(plan, ax, color="C1", label=None, show_waypoints=True, extra_color
 
         if isinstance(plan, FlightPlan):
             centers = set(
-                [
-                    (c.center.lon, c.center.lat, c.center.label)
-                    for c in plan.circles
-                ]
+                [(c.center.lon, c.center.lat, c.center.label) for c in plan.circles]
             )
             labels |= centers
 

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -488,9 +488,8 @@ def plot_path(plan, ax, color="C1", label=None, show_waypoints=True, extra_color
         if isinstance(plan, FlightPlan):
             centers = set(
                 [
-                    (p.center.lon, p.center.lat, p.center.label)
-                    for p in plan.path
-                    if isinstance(p, IntoCircle)
+                    (c.center.lon, c.center.lat, c.center.label)
+                    for c in plan.circles
                 ]
             )
             labels |= centers

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -866,12 +866,27 @@ def export_flightplan(flight_id_or_plan, plan=None):
     from ipywidgets import HTML
     from IPython.display import display
 
-    kml = to_kml(plan)
-    geojson = to_geojson(plan)
-    txt = to_txt(plan)
+    exports = [
+        (
+            ".geojson",
+            "GeoJSON",
+            "application/geo+json",
+            to_geojson(plan).encode("utf-8"),
+        ),
+        (
+            ".kml",
+            "KML",
+            "application/vnd.google-earth.kml+xml",
+            to_kml(plan).encode("utf-8"),
+        ),
+    ]
+    if isinstance(plan, FlightPlan):
+        exports.append(
+            ("_waypoints.txt", "TXT", "text/plain", to_txt(plan).encode("utf-8"))
+        )
 
     # BUTTONS
-    html = f"""<html>
+    html = """<html>
     <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>
@@ -879,15 +894,14 @@ def export_flightplan(flight_id_or_plan, plan=None):
     <h2>
     Download Flightplan as:
     </h2>
-    <a download="{flight_id}.geojson" href="{as_href(geojson.encode('utf-8'), 'application/geo+json')}" download>
-    <button class="p-Widget jupyter-widgets jupyter-button widget-button mod-warning">GeoJSON</button>
-    </a>
-    <a download="{flight_id}.kml" href="{as_href(kml.encode('utf-8'), 'application/vnd.google-earth.kml+xml')}" download>
-    <button class="p-Widget jupyter-widgets jupyter-button widget-button mod-warning">KML</button>
-    </a>
-    <a download="{flight_id}_waypoints.txt" href="{as_href(txt.encode('utf-8'), 'text/plain')}" download>
-    <button class="p-Widget jupyter-widgets jupyter-button widget-button mod-warning">TXT</button>
-    </a>
+    """
+    for suffix, name, mime, data in exports:
+        html += f"""
+            <a download="{flight_id}{suffix}" href="{as_href(data, mime)}" download>
+            <button class="p-Widget jupyter-widgets jupyter-button widget-button mod-warning">{name}</button>
+            </a>
+            """
+    html += """
     </body>
     </html>
     """

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -178,6 +178,9 @@ class FlightPlan:
     def show_details(self):
         print(to_detailed_txt(self))
 
+    def export(self):
+        return export_flightplan(self)
+
 
 def attach_flight_performance(ds, performance):
     second = np.timedelta64(1000000000, "ns")

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -795,15 +795,6 @@ def to_txt(plan: FlightPlan):
                 f"circle around {point.center.label:12s} {point.center.format_pilot():20s}, FL{point.center.fl:03d}, {tstart:%H:%M:%S %Z} - {tend:%H:%M:%S %Z}, radius: {radius_nm:.0f} nm, {abs(point.angle):.0f}° {direction}, enter from {az_to_text(az21)}, {point.center.note or ''}\n"
             )
 
-    file.write("\n -- circle centers:")
-    for point in plan.path:
-        if isinstance(point, IntoCircle):
-            point = point.center
-            file.write(f"\n{point.label:12s} {point.format_pilot()}")
-    file.write("\n\n -- extra waypoints:")
-    for point in plan.extra_waypoints:
-        file.write(f"\n{point.label:12s} {point.format_pilot()}, {point.note or ''}")
-
     file.write("\n\nCrew:")
     for position, person in plan.crew.items():
         file.write(f"\n{position:22s} {person}")

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -175,6 +175,9 @@ class FlightPlan:
     def landing_time(self):
         return self.computed_time_at_raw_index(-1, end=True)
 
+    def show_details(self):
+        print(to_detailed_txt(self))
+
 
 def attach_flight_performance(ds, performance):
     second = np.timedelta64(1000000000, "ns")

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -76,6 +76,7 @@ class LatLon:
     label: Optional[str] = None
     fl: Optional[float] = None
     time: Optional[datetime.datetime | str] = None
+    note: Optional[str] = None
 
     def __post_init__(self):
         if isinstance(self.time, (str, np.datetime64, xr.DataArray)):


### PR DESCRIPTION
This PR adds automatic flight plan export to the TXT format.
The PR is a bit larger than I hoped it to be, that's because of two reasons:
* in order to be able to export in the TXT format, more information, then just the waypoints is needed
* the PR aims to be backwards compatible, i.e. previous code should still work

To gather all required information, the `FlightPlan` class is introduced, which should from now on be used to bundle waypoints, extra_waypoints, flight_id and crew into one object. The `FlightPlan` object can then be used in all places where previously a list of waypoints or the flightplan dataset was expected. However, some new functionality (notable the TXT export) is only possible when using the `FlightPlan` object.

The `FlightPlan` object further provides a couple of convenience properties and methods such as:

* `takeoff_time`
* `landing_time`
* `show_details()`
* `export()`