### PR TITLE
flightplan: add first_point and last_point

### DIFF
--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -464,6 +464,20 @@ def track_len(ds):
     return path_len(ds)
 
 
+def first_point(path):
+    ds = path_as_ds(path)
+    lat = float(ds.lat.values[0])
+    lon = float(ds.lon.values[0])
+    return LatLon(lat, lon)
+
+
+def last_point(path):
+    ds = path_as_ds(path)
+    lat = float(ds.lat.values[-1])
+    lon = float(ds.lon.values[-1])
+    return LatLon(lat, lon)
+
+
 def plot_path(plan, ax, color="C1", label=None, show_waypoints=True, extra_color="C3"):
     import cartopy.crs as ccrs
 


### PR DESCRIPTION
The two new functions `first_point` and `last_point` return the first or last point of a given flight plan respectively. It is expected to use these functions on partial flight plans to retrieve points which are not defined explicitly, but only as a result of a flight plan computation.