### PR TITLE
Refinement of `FlightPlan` API

### DIFF
--- a/orcestra/flight_performance.py
+++ b/orcestra/flight_performance.py
@@ -54,3 +54,10 @@ def set_current_performance(name_or_performance):
     if isinstance(name_or_performance, str):
         return set_current_performance(aircraft_performance[name_or_performance])
     CURRENT_PERFORMANCE = name_or_performance
+
+
+def get_flight_performance(aircraft=None):
+    if aircraft is None:
+        return get_current_performance()
+    else:
+        return aircraft_performance[aircraft]

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -263,6 +263,9 @@ class FlightPlan:
     def preview(self, **kwargs):
         return path_preview(self, **kwargs)
 
+    def profile(self, **kwargs):
+        return vertical_preview(self, **kwargs)
+
 
 def attach_flight_performance(ds, performance):
     second = np.timedelta64(1000000000, "ns")
@@ -1011,7 +1014,7 @@ def export_flightplan(flight_id_or_plan, plan=None):
             to_kml(plan).encode("utf-8"),
         ),
     ]
-    if isinstance(plan, FlightPlan):
+    if isinstance(plan, FlightPlan) and "time" in plan.ds:
         exports.append(
             ("_waypoints.txt", "TXT", "text/plain", to_txt(plan).encode("utf-8"))
         )

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -132,6 +132,7 @@ class LatLon:
 
 
 bco = LatLon(13.079773, -59.487634, "BCO", fl=0)
+bgi = tbpb = LatLon(13.074722, -59.4925, "TBPB", fl=0)
 sal = LatLon(16.73448797020352, -22.94397423993749, "SAL", fl=0)
 mindelo = LatLon(16.877810, -24.995002, "MINDELO", fl=0)
 

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -241,6 +241,19 @@ class FlightPlan:
     def landing_time(self):
         return self.computed_time_at_raw_index(-1, end=True)
 
+    @cached_property
+    def duration(self):
+        self._require_flightlevels()
+        self._require_performance()
+        try:
+            d1 = self.ds.duration.values[0]
+            d2 = self.ds.duration.values[-1]
+        except AttributeError:
+            raise AttributeError(
+                "FlightPlan.duration could not be computed. Maybe you are missing flight level or aircraft performance data?"
+            )
+        return pd.Timedelta(d2 - d1).to_pytimedelta()
+
     def show_details(self):
         print(to_detailed_txt(self))
 

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -660,12 +660,12 @@ def vertical_preview(path):
 
 
 def path_preview(
-    path, coastlines=True, gridlines=True, ax=None, size=8, aspect=16 / 9, **kwargs
+    plan, coastlines=True, gridlines=True, ax=None, size=8, aspect=16 / 9, **kwargs
 ):
     import matplotlib.pylab as plt
     import cartopy.crs as ccrs
 
-    path = path_as_ds(path)
+    path = path_as_ds(plan)
 
     lon_min = path.lon.values.min()
     lon_max = path.lon.values.max()
@@ -704,7 +704,7 @@ def path_preview(
         no_cartopy_download_warning()
         ax.gridlines(draw_labels=True, alpha=0.25)
 
-    plot_path(path, ax=ax, label="path", **kwargs)
+    plot_path(plan, ax=ax, label="path", **kwargs)
     return ax
 
 

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -206,6 +206,9 @@ class FlightPlan:
     def export(self):
         return export_flightplan(self)
 
+    def preview(self, **kwargs):
+        return path_preview(self, **kwargs)
+
 
 def attach_flight_performance(ds, performance):
     second = np.timedelta64(1000000000, "ns")


### PR DESCRIPTION
This PR introduces a bunch of small changes, which are intended to further simplify using the `FlightPlan` API.

* It adds helper methods: `.profile()`, `.preview()` and the `.duration` property as shortcuts for common tasks
* It improves error messages
* It skips automatic TXT export if time (and thus the export format) can't be computed instead of failing
* It adds the coordinates of `TBPB`
* It allows (and recommends) to explicitly specify the aircraft for flight performance computations
* It ensures that `path_preview` shows the recent updates to `plot_path` by passing the `FlightPlan` object along
* It requires to set a `flight_id` for flightplan export (as otherwise, the filename would be nonsensical)