### PR TITLE
add func to load flight segmentation info

### DIFF
--- a/orcestra/__init__.py
+++ b/orcestra/__init__.py
@@ -1,5 +1,5 @@
 from .flightplan import LatLon, bco, sal
-from .utils import parse_datestr
+from .utils import parse_datestr, get_flight_segments
 from .io import read_igi, read_bahamas_100hz
 
 import warnings
@@ -14,4 +14,12 @@ warnings.filterwarnings(
     module="intake_xarray",
 )
 
-__all__ = ["LatLon", "bco", "sal", "parse_datestr", "read_igi", "read_bahamas_100hz"]
+__all__ = [
+    "LatLon",
+    "bco",
+    "sal",
+    "parse_datestr",
+    "get_flight_segments",
+    "read_igi",
+    "read_bahamas_100hz",
+]

--- a/orcestra/utils.py
+++ b/orcestra/utils.py
@@ -9,6 +9,7 @@ import pandas as pd
 import xarray as xr
 import matplotlib.pyplot as plt
 import yaml
+import fsspec
 
 
 def parse_datestr(datestr):
@@ -100,3 +101,13 @@ def export_planet(fname, fig=None, dpi=144, stem_ext="_planet", **kwargs):
         },
         **kwargs,
     )
+
+
+@lru_cache
+def get_flight_segments():
+    flight_segment_file = (
+        "https://orcestra-campaign.github.io/flight_segmentation/all_flights.yaml"
+    )
+    with fsspec.open(flight_segment_file) as f:
+        meta = yaml.safe_load(f)
+    return meta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ cartopy = "*"
 cmocean = "*"
 easygems = ">=0.0.8"
 flox = "*"  # part of xarray[accel]
+fsspec = "*"
 geopandas = "*"
 gpxpy = "*"
 healpix = "*"


### PR DESCRIPTION
This PR adds the function `get_flight_segments` that essentially loads a YAML file currently available [here](https://orcestra-campaign.github.io/flight_segmentation/all_flights.yaml). This YAML currently includes only HALO flights but can and shall grow to include further platforms.