### PR TITLE
Update overpass_time function using nanargmin for calculating overpass time

### DIFF
--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -32,21 +32,24 @@ def overpass_time(
     """
     Returns distance and time at closet overpass. Default assumes second platform is HALO
     tracks from BAHAMAS (with well formed time dimension) and has higher rate temporal data.
-    With the parameter n you can search for multiple overpasses, as e.g. during some flights 
+    With the parameter n you can search for multiple overpasses, as e.g. during some flights
     of the third part of PERCUSION, multiple meetings of EarthCARE and HALO were achieved
     """
     x = x_track.interp(time=y_track.time)
     az12, az21, dist = geod.inv(x[x_lon], x[x_lat], y_track[y_lon], y_track[y_lat])
     if n > 1:
         dist_diff = np.diff(dist)
-        local_minima_indices = np.where((dist_diff[:-1] < 0) & (dist_diff[1:] > 0))[0] + 1
+        local_minima_indices = (
+            np.where((dist_diff[:-1] < 0) & (dist_diff[1:] > 0))[0] + 1
+        )
         min_dists = dist[local_minima_indices]
-        #sort by distance to get the n closest overpasses
+        # sort by distance to get the n closest overpasses
         closest_indices = np.argsort(min_dists)[:n]
         overpass_indices = local_minima_indices[closest_indices]
         return dist[np.sort(overpass_indices)], y_track.time[np.sort(overpass_indices)]
     else:
         return np.nanmin(dist), y_track.time[np.nanargmin(dist)]
+
 
 def no_cartopy_download_warning():
     import warnings

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -27,7 +27,14 @@ geod = pyproj.Geod(ellps="WGS84")
 
 
 def overpass_time(
-    x_track, y_track, x_lon="lon", x_lat="lat", y_lon="IRS_LON", y_lat="IRS_LAT", n=1, min_timedelta=np.timedelta64(1, 'h')
+    x_track,
+    y_track,
+    x_lon="lon",
+    x_lat="lat",
+    y_lon="IRS_LON",
+    y_lat="IRS_LAT",
+    n=1,
+    min_timedelta=np.timedelta64(1, "h"),
 ):
     """
     Returns distance and time at closet overpass. Default assumes second platform is HALO
@@ -38,7 +45,7 @@ def overpass_time(
     x = x_track.interp(time=y_track.time)
     az12, az21, dist = geod.inv(x[x_lon], x[x_lat], y_track[y_lon], y_track[y_lat])
     if n > 1:
-        mean_time_diff = x.time.diff(dim='time').mean(dim='time')
+        mean_time_diff = x.time.diff(dim="time").mean(dim="time")
         min_time_step = np.ceil(min_timedelta / mean_time_diff)
         local_minima_indices = scipy.signal.find_peaks(-dist, distance=min_time_step)[0]
         min_dists = dist[local_minima_indices]

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -27,15 +27,26 @@ geod = pyproj.Geod(ellps="WGS84")
 
 
 def overpass_time(
-    x_track, y_track, x_lon="lon", x_lat="lat", y_lon="IRS_LON", y_lat="IRS_LAT"
+    x_track, y_track, x_lon="lon", x_lat="lat", y_lon="IRS_LON", y_lat="IRS_LAT", n=1
 ):
     """
     Returns distance and time at closet overpass. Default assumes second platform is HALO
     tracks from BAHAMAS (with well formed time dimension) and has higher rate temporal data.
+    With the parameter n you can search for multiple overpasses, as e.g. during some flights 
+    of the third part of PERCUSION, multiple meetings of EarthCARE and HALO were achieved
     """
     x = x_track.interp(time=y_track.time)
     az12, az21, dist = geod.inv(x[x_lon], x[x_lat], y_track[y_lon], y_track[y_lat])
-    return dist, y_track.time[np.nanargmin(dist)]
+    if n > 1:
+        dist_diff = np.diff(dist)
+        local_minima_indices = np.where((dist_diff[:-1] < 0) & (dist_diff[1:] > 0))[0] + 1
+        min_dists = dist[local_minima_indices]
+        #sort by distance to get the n closest overpasses
+        closest_indices = np.argsort(min_dists)[:n]
+        overpass_indices = local_minima_indices[closest_indices]
+        return dist[np.sort(overpass_indices)], y_track.time[np.sort(overpass_indices)]
+    else:
+        return np.nanmin(dist), y_track.time[np.nanargmin(dist)]
 
 def no_cartopy_download_warning():
     import warnings

--- a/orcestra/flightplan.py
+++ b/orcestra/flightplan.py
@@ -35,8 +35,7 @@ def overpass_time(
     """
     x = x_track.interp(time=y_track.time)
     az12, az21, dist = geod.inv(x[x_lon], x[x_lat], y_track[y_lon], y_track[y_lat])
-    return dist, y_track.time[dist.argmin()]
-
+    return dist, y_track.time[np.nanargmin(dist)]
 
 def no_cartopy_download_warning():
     import warnings


### PR DESCRIPTION
We noticed, that the overpass times calculated using the overpass_time function in flightplan.py were not correct due to nan values in the data. Using nanargmin corrects for that.